### PR TITLE
payton: set verity to EIO mode, bypass verity

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -27,6 +27,7 @@ BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := $(DEVICE_PATH)/bluetooth
 
 # Kernel
 TARGET_KERNEL_CONFIG := lineageos_payton_defconfig
+BOARD_KERNEL_CMDLINE += androidboot.veritymode=eio
 
 # Partitions
 BOARD_BOOTIMAGE_PARTITION_SIZE := 0x04000000


### PR DESCRIPTION
This will prevent verity from restarting if verification fails.

This adds serious security issues since we are bypassing verity.

https://source.android.com/security/verifiedboot/verified-boot#boot_partition